### PR TITLE
fix: 다크모드 토글 시 페이지 리로드

### DIFF
--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -163,6 +163,8 @@ export default function Menu({
     document.documentElement.className = newTheme
 
     setCookie("theme", newTheme, 30)
+
+    window.location.reload()
   }
 
   useEffect(() => {


### PR DESCRIPTION
수정분 : 토글 시 window.location.reload() 추가

[내용]
F5와 Link (메뉴로 이동) 의 동작이 다름.
F5 : layout / page 재렌더링
Link : 캐시 사용

예를 들어, 
초기에 light 모드였을 때
dark 모드로 토글을 했으나 
Link 로 다른화면으로 이동하면 layout 은 light 로 캐시되어 있는 상태임.
토글 시 화면 reload 한번 해주면 해당 모드로 다시 캐시됨