### PR TITLE
fix: 그라파나 플리커링 방지, 새탭창 재사용

### DIFF
--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -117,7 +117,8 @@ export default function Menu({
     const url = menu.url ?? ""
     const width = menu.screen_width ?? 800
     const height = menu.screen_width ?? 600
-    window.open(url, "_blank", `noopener,noreferrer,width=${width},height=${height},top=50,left=50`)
+    // 아이디로 추적할거면 noopener,noreferrer 못씀
+    window.open(url, url, `width=${width},height=${height},top=50,left=50`)
   }
 
   function renderMenuLink(menu: MenuType) {
@@ -134,8 +135,9 @@ export default function Menu({
       }
       // 새탭
       if (menu.pop_up_yn_code === "T") {
+        // 아이디로 추적할거면 rel="noopener noreferrer" 못씀
         return (
-          <Link href={menu.url ?? ""} target="_blank" rel="noopener noreferrer">
+          <Link href={menu.url ?? ""} target={menu.url ?? ""}>
             {menu.menu_name}
           </Link>
         )

--- a/src/components/dashboard/GrafanaIframe.tsx
+++ b/src/components/dashboard/GrafanaIframe.tsx
@@ -1,7 +1,8 @@
 import { grafanaThemeAtom } from "@/atom/dashboardAtom"
 import { useContextPath } from "@/config/Providers"
+import { Box } from "@mui/material"
 import { useAtom } from "jotai"
-import { useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 interface GrafanaIframeProps {
   src: string
@@ -13,6 +14,7 @@ export function GrafanaIframe({ src, selected, title }: GrafanaIframeProps) {
   const contextPath = useContextPath()
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const [theme] = useAtom(grafanaThemeAtom)
+  const [loaded, setLoaded] = useState(false)
 
   // height 자동조정 스크립트. 11버전으로 가면서(autofitheight) 필요없어짐.
 
@@ -55,6 +57,22 @@ export function GrafanaIframe({ src, selected, title }: GrafanaIframeProps) {
   //     if (intervalRef.current) clearInterval(intervalRef.current)
   //   }
   // }, [adjustHeight, selected])
+
+  useEffect(() => {
+    setLoaded(true)
+  }, [])
+
+  if (!loaded) {
+    return (
+      <Box
+        sx={{
+          width: "100%",
+          height: "750px", // iframe과 동일한 높이
+          backgroundColor: "transparent", // 배경 투명
+        }}
+      />
+    )
+  }
 
   return (
     <iframe


### PR DESCRIPTION
다크모드에서 화면 새로고침 시 디폴트가 white 이기 때문에 흰색이 잠깐 비치는 현상
새 탭 및 새 창에 url 과 동일한 아이디를 줘서 재사용하도록