### PR TITLE
Pub 1121 fix

### DIFF
--- a/src/app/commonLayout.tsx
+++ b/src/app/commonLayout.tsx
@@ -23,7 +23,7 @@ export default async function CommonLayout({ children }: { children: React.React
       <div className="w-full">
         <div className="flex h-screen flex-col dark:bg-black">
           {/* Header Section */}
-          <Paper className="mb-6 rounded-none p-4 shadow-md dark:bg-black">
+          <Paper className="rounded-none border-none p-4 dark:bg-black">
             <Top breadcrumbs={breadcrumbs} />
             {/* <div style={{ width: 50, height: 20 }} /> */}
             {children}

--- a/src/app/equip/page.tsx
+++ b/src/app/equip/page.tsx
@@ -12,12 +12,12 @@ export default function Page() {
   return (
     <Box display="flex">
       {/* Left: TreeView */}
-      <Box width="30%" mr={2}>
+      <Box width="20%" mr={2}>
         <EquipTree onSelectEquipTypeCode={setSelectedEquipTypeCode} />
       </Box>
 
       {/* Right: Table */}
-      <Box width="70%">
+      <Box width="80%" className="border-l-2 pl-6 dark:border-gray-600">
         <EquipTable selectedEquipTypeCode={selectedEquipTypeCode} />
       </Box>
     </Box>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,12 +17,14 @@ export default function RootLayout({
 }>) {
   // 다크모드 초기 flickering 방지
   const cookie = cookies()
-  const theme = cookie.get("theme")?.value ?? "light"
+  const theme = (cookie.get("theme")?.value as "dark" | "light") ?? "light"
 
+  // html 에 넣는 theme 은 tailwindcss 용
+  // Providers 에 넣는 theme 은 mui 용
   return (
     <html lang="ko" className={theme}>
       <body className={`${notoSansKR.className} antialiased`}>
-        <Providers>{children}</Providers>
+        <Providers darkLightTheme={theme}>{children}</Providers>
       </body>
     </html>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -23,7 +23,7 @@ export default async function Login({
         </Box>
 
         <Box className="flex w-full items-center justify-center p-0 md:p-8 lg:w-1/2">
-          <Box className="w-full max-w-md rounded-lg bg-white bg-opacity-90 px-10 py-12 shadow-lg">
+          <Box className="login_box_wrap w-full max-w-md rounded-lg bg-white bg-opacity-90 px-10 py-12 shadow-lg">
             <Box className="mb-6 flex justify-center">
               <Image src="/logo.png" alt="로고" width={130} height={40} className="h-10" />
             </Box>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { MiniBoard } from "@/components/main/MiniBoard"
-import { notoSansKR } from "@/styles/fonts"
 import { Box, Grid, Typography } from "@mui/material"
 import Image from "next/image"
 
@@ -20,40 +19,83 @@ function DashboardLayout() {
             <hr className="mx-auto my-4 w-14 border-t-2 border-gray-300 opacity-60" />
             <Typography
               variant="h4"
-              className={`${notoSansKR.className} mb-2 break-keep font-semibold`}
+              // className={`${notoSansKR.className} mb-2 break-keep font-semibold`}
+              sx={{
+                marginBottom: "0.5rem",
+                wordBreak: "keep-all",
+                fontWeight: 600,
+                fontFamily: "Noto Sans KR",
+              }}
             >
               미래의 연결, 혁신의 시작
             </Typography>
-            <Typography variant="body1" className={`${notoSansKR.className} break-keep`}>
+            <Typography
+              variant="body1"
+              // className={`${notoSansKR.className} break-keep`}
+              sx={{
+                wordBreak: "keep-all",
+                fontFamily: "Noto Sans KR",
+              }}
+            >
               첨단 기술로 변화하는 도시와 산업의 동반자, S·NMS가 함께합니다.
             </Typography>
           </Box>
         </Box>
 
         {/* Main Content */}
-        <Grid container spacing={2} className="!m-0 w-full px-6 py-8">
-          {/* 공지사항 */}
+        <Grid
+          container
+          spacing={2}
+          // className="!m-0 w-full px-6 py-8"
+          sx={{
+            margin: 0,
+            width: "100%",
+            paddingX: { xs: "0.5rem", md: "0.5rem" }, // 좌우 패딩 균등
+            paddingY: { xs: "0.5rem", md: "0.5rem" }, // 상하 패딩 균등
+          }}
+        >
           <Grid
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pt-1 pb-6 dark:border-gray-500 md:border-b-0 md:border-r md:!pb-2 md:!pr-6"
+            // className="border-b border-gray-300 !px-1 !pt-1 pb-6 dark:border-gray-500 md:border-b-0 md:border-r md:!pb-2 md:!pr-6"
+            sx={{
+              borderBottom: { xs: "1px solid rgb(209, 213, 219)", md: "none" }, // 좁은 화면에서는 하단 경계선, 넓은 화면에서는 없음
+              borderRight: { md: "1px solid rgb(209, 213, 219)" }, // 넓은 화면에서만 오른쪽 경계선
+              paddingX: { xs: "0.5rem", md: "1rem" }, // 좌우 패딩 균등
+              paddingTop: { xs: "0.5rem", md: "1rem" }, // 상하 패딩 균등
+              paddingBottom: { xs: "1rem", md: "1rem" }, // 상하 패딩 균등
+            }}
           >
             <MiniBoard section="NOTICE" label="공지사항" />
           </Grid>
 
-          {/* 메뉴얼(SOP) */}
           <Grid
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pb-6 !pt-4 dark:border-gray-500 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1"
+            // className="border-b border-gray-300 !px-1 !pb-6 !pt-4 dark:border-gray-500 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1"
+            sx={{
+              borderBottom: { xs: "1px solid rgb(209, 213, 219)", md: "none" },
+              borderRight: { md: "1px solid rgb(209, 213, 219)" },
+              paddingX: { xs: "0.5rem", md: "1rem" },
+              paddingTop: { xs: "0.5rem", md: "1rem" }, // 상하 패딩 균등
+              paddingBottom: { xs: "1rem", md: "1rem" }, // 상하 패딩 균등
+            }}
           >
             <MiniBoard section="MANUAL" label="매뉴얼(SOP)" />
           </Grid>
 
-          {/* 작업계획 */}
-          <Grid item xs={12} md={4} className="!px-1 !pb-6 !pt-4 md:!pb-2 md:!pl-6 md:!pt-1">
+          <Grid
+            item
+            xs={12}
+            md={4}
+            // className="!px-1 !pb-6 !pt-4 md:!pb-2 md:!pl-6 md:!pt-1"
+            sx={{
+              paddingX: { xs: "0.5rem", md: "1rem" },
+              paddingY: { xs: "0.5rem", md: "1rem" },
+            }}
+          >
             <MiniBoard section="TASK" label="작업계획" />
           </Grid>
         </Grid>
@@ -79,7 +121,17 @@ function DashboardLayout() {
         </Box> */}
 
         <Box className="flex flex-col bg-gray-100 px-6 py-8 dark:bg-gray-900 md:flex-row">
-          <Typography variant="h6" className="w-full font-bold md:w-1/12">
+          <Typography
+            variant="h6"
+            // className="w-full font-bold md:w-1/12"
+            sx={{
+              width: "100%",
+              fontWeight: 700,
+              "@media (min-width:900px)": {
+                width: "8.333333%",
+              },
+            }}
+          >
             FAQ
           </Typography>
           <ul className="mt-6 flex w-full flex-col space-y-6 md:mt-0 md:w-11/12 md:flex-row md:space-x-4 md:space-y-0">
@@ -142,7 +194,17 @@ function DashboardLayout() {
 
         {/* Q&A */}
         <Box className="flex flex-col px-6 py-8 dark:bg-black dark:text-white md:flex-row">
-          <Typography variant="h6" className="w-full font-bold md:w-1/12">
+          <Typography
+            variant="h6"
+            // className="w-full font-bold md:w-1/12"
+            sx={{
+              width: "100%",
+              fontWeight: 700,
+              "@media (min-width:900px)": {
+                width: "8.333333%",
+              },
+            }}
+          >
             Q&A
           </Typography>
           <ul className="mt-6 flex w-full flex-col space-y-6 md:mt-0 md:w-11/12 md:flex-row md:space-x-4 md:space-y-0">

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -10,18 +10,21 @@ function DashboardLayout() {
   return (
     <div className="flex h-screen flex-col">
       {/* Banner */}
-      <Box className="min-h-screen">
+      <Box className="min-h-screen dark:bg-black dark:text-white">
         <Box
           className="relative h-80 bg-cover bg-center"
           style={{ backgroundImage: "url('/login_bg.png')" }}
         >
-          <Box className="absolute inset-0 flex flex-col items-center justify-center pb-2 text-center text-white">
+          <Box className="absolute inset-0 flex flex-col items-center justify-center px-6 pb-2 text-center text-white">
             <Image src="/logo_w.png" width="130" height="40" alt="로고" className="h-10" />
             <hr className="mx-auto my-4 w-14 border-t-2 border-gray-300 opacity-60" />
-            <Typography variant="h4" className={`${notoSansKR.className} mb-2 font-semibold`}>
+            <Typography
+              variant="h4"
+              className={`${notoSansKR.className} mb-2 break-keep font-semibold`}
+            >
               미래의 연결, 혁신의 시작
             </Typography>
-            <Typography variant="body1" className={`${notoSansKR.className}`}>
+            <Typography variant="body1" className={`${notoSansKR.className} break-keep`}>
               첨단 기술로 변화하는 도시와 산업의 동반자, S·NMS가 함께합니다.
             </Typography>
           </Box>
@@ -34,7 +37,7 @@ function DashboardLayout() {
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pt-1 pb-6 md:border-b-0 md:border-r md:!pb-2 md:!pr-6"
+            className="border-b border-gray-300 !px-1 !pt-1 pb-6 md:border-b-0 md:border-r md:!pb-2 md:!pr-6 dark:border-gray-500"
           >
             <MiniBoard section="NOTICE" label="공지사항" />
           </Grid>
@@ -44,18 +47,13 @@ function DashboardLayout() {
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pb-6 !pt-4 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1"
+            className="border-b border-gray-300 !px-1 !pb-6 !pt-4 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1 dark:border-gray-500"
           >
             <MiniBoard section="MANUAL" label="매뉴얼(SOP)" />
           </Grid>
 
           {/* 작업계획 */}
-          <Grid
-            item
-            xs={12}
-            md={4}
-            className="border-gray-300 !px-1 !pb-6 !pt-4 md:!pb-2 md:!pl-6 md:!pt-1"
-          >
+          <Grid item xs={12} md={4} className="!px-1 !pb-6 !pt-4 md:!pb-2 md:!pl-6 md:!pt-1">
             <MiniBoard section="TASK" label="작업계획" />
           </Grid>
         </Grid>
@@ -80,17 +78,17 @@ function DashboardLayout() {
           </ul>
         </Box> */}
 
-        <Box className="flex flex-col px-6 py-8 md:flex-row">
-          <Typography variant="h6" className="w-full font-bold md:w-24">
+        <Box className="flex flex-col bg-gray-100 px-6 py-8 md:flex-row dark:bg-gray-900">
+          <Typography variant="h6" className="w-full font-bold md:w-1/12">
             FAQ
           </Typography>
-          <ul className="mt-3 flex w-full space-x-4 md:mt-0">
-            <li className="w-1/4 cursor-pointer hover:text-primary">
+          <ul className="mt-6 flex w-full flex-col space-y-6 md:mt-0 md:w-11/12 md:flex-row md:space-x-4 md:space-y-0">
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
               <Box className="flex items-center space-x-2">
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
                   Q
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   5G NMS 활용, 무선망 코어 & 엑세스 스위치 감시 체계 관련 문의 드립니다.
                 </span>
               </Box>
@@ -98,17 +96,17 @@ function DashboardLayout() {
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
                   A
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   5G NMS 활용, 무선망 코어 & 엑세스 스위치 감시 체계 관련 안내입니다.
                 </span>
               </Box>
             </li>
-            <li className="w-1/4 cursor-pointer hover:text-primary">
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
               <Box className="flex items-center space-x-2">
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
                   Q
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   무선 VOC 응대시스템 권한신청 매뉴얼 장애 해결을 위한 질문입니다.
                 </span>
               </Box>
@@ -116,7 +114,25 @@ function DashboardLayout() {
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
                   A
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
+                  무선 VOC 응대시스템 권한신청 매뉴얼 장애 해결을 위한 조치 방법입니다.
+                </span>
+              </Box>
+            </li>
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
+              <Box className="flex items-center space-x-2">
+                <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
+                  Q
+                </Typography>
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
+                  무선 VOC 응대시스템 권한신청 매뉴얼 장애 해결을 위한 질문입니다.
+                </span>
+              </Box>
+              <Box className="mt-2 flex items-center space-x-2">
+                <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
+                  A
+                </Typography>
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   무선 VOC 응대시스템 권한신청 매뉴얼 장애 해결을 위한 조치 방법입니다.
                 </span>
               </Box>
@@ -125,17 +141,17 @@ function DashboardLayout() {
         </Box>
 
         {/* Q&A */}
-        <Box className="flex flex-col bg-gray-100 px-6 py-8 md:flex-row">
-          <Typography variant="h6" className="w-full font-bold md:w-24">
+        <Box className="flex flex-col px-6 py-8 md:flex-row dark:bg-black dark:text-white">
+          <Typography variant="h6" className="w-full font-bold md:w-1/12">
             Q&A
           </Typography>
-          <ul className="mt-3 flex w-full space-x-4 md:mt-0">
-            <li className="w-1/4 cursor-pointer hover:text-primary">
+          <ul className="mt-6 flex w-full flex-col space-y-6 md:mt-0 md:w-11/12 md:flex-row md:space-x-4 md:space-y-0">
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
               <Box className="flex items-center space-x-2">
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
                   Q
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   안녕하세요? 2024년 9월 4일 특정국소의 전기정보관리 입력 관련 문의입니다.
                 </span>
               </Box>
@@ -143,17 +159,17 @@ function DashboardLayout() {
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
                   A
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   답변 준비 중 입니다.
                 </span>
               </Box>
             </li>
-            <li className="w-1/4 cursor-pointer">
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
               <Box className="flex items-center space-x-2">
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
                   Q
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   안녕하세요? 2024년 9월 4일 특정국소의 전기정보관리 입력 관련 문의입니다.
                 </span>
               </Box>
@@ -161,7 +177,25 @@ function DashboardLayout() {
                 <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
                   A
                 </Typography>
-                <span className="truncate text-gray-800 hover:text-primary">
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
+                  실제로 WCDMA 품질 보고가 누락되어 발생한 정상 장애입니다.
+                </span>
+              </Box>
+            </li>
+            <li className="w-full cursor-pointer hover:text-primary md:w-1/3">
+              <Box className="flex items-center space-x-2">
+                <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-gray-600 text-center font-medium text-white">
+                  Q
+                </Typography>
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
+                  안녕하세요? 2024년 9월 4일 특정국소의 전기정보관리 입력 관련 문의입니다.
+                </span>
+              </Box>
+              <Box className="mt-2 flex items-center space-x-2">
+                <Typography className="h-6 min-w-8 max-w-8 rounded-md bg-red-500 text-center font-medium text-white">
+                  A
+                </Typography>
+                <span className="truncate text-gray-800 hover:text-primary dark:text-white">
                   실제로 WCDMA 품질 보고가 누락되어 발생한 정상 장애입니다.
                 </span>
               </Box>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -37,7 +37,7 @@ function DashboardLayout() {
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pt-1 pb-6 md:border-b-0 md:border-r md:!pb-2 md:!pr-6 dark:border-gray-500"
+            className="border-b border-gray-300 !px-1 !pt-1 pb-6 dark:border-gray-500 md:border-b-0 md:border-r md:!pb-2 md:!pr-6"
           >
             <MiniBoard section="NOTICE" label="공지사항" />
           </Grid>
@@ -47,7 +47,7 @@ function DashboardLayout() {
             item
             xs={12}
             md={4}
-            className="border-b border-gray-300 !px-1 !pb-6 !pt-4 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1 dark:border-gray-500"
+            className="border-b border-gray-300 !px-1 !pb-6 !pt-4 dark:border-gray-500 md:border-b-0 md:border-r md:!px-6 md:!pb-2 md:!pt-1"
           >
             <MiniBoard section="MANUAL" label="매뉴얼(SOP)" />
           </Grid>
@@ -78,7 +78,7 @@ function DashboardLayout() {
           </ul>
         </Box> */}
 
-        <Box className="flex flex-col bg-gray-100 px-6 py-8 md:flex-row dark:bg-gray-900">
+        <Box className="flex flex-col bg-gray-100 px-6 py-8 dark:bg-gray-900 md:flex-row">
           <Typography variant="h6" className="w-full font-bold md:w-1/12">
             FAQ
           </Typography>
@@ -141,7 +141,7 @@ function DashboardLayout() {
         </Box>
 
         {/* Q&A */}
-        <Box className="flex flex-col px-6 py-8 md:flex-row dark:bg-black dark:text-white">
+        <Box className="flex flex-col px-6 py-8 dark:bg-black dark:text-white md:flex-row">
           <Typography variant="h6" className="w-full font-bold md:w-1/12">
             Q&A
           </Typography>

--- a/src/app/manage/code/page.tsx
+++ b/src/app/manage/code/page.tsx
@@ -203,7 +203,7 @@ export default function CodeManager() {
       </Box>
 
       {/* 우측: 코드 목록 및 검색 */}
-      <Box width="80%" className="border-l-2 pl-6">
+      <Box width="80%" className="border-l-2 pl-6 dark:border-gray-600">
         <Box display="flex" alignItems="center" gap={1} mb={2}>
           <TextField
             variant="outlined"

--- a/src/app/manage/code/page.tsx
+++ b/src/app/manage/code/page.tsx
@@ -7,6 +7,7 @@ import DeleteIcon from "@mui/icons-material/Delete"
 import {
   Box,
   Button,
+  CircularProgress,
   Divider,
   IconButton,
   Table,
@@ -28,7 +29,12 @@ export default function CodeManager() {
   const [editCodes, setEditCodes] = useState<CommonCodeEdit[]>([])
   const [newCategory, setNewCategory] = useState<string>("")
 
-  const { data: codes = [], refetch } = useQuery({
+  const {
+    data: codes = [],
+    refetch,
+    isLoading,
+    isFetching,
+  } = useQuery({
     queryKey: ["codes"],
     queryFn: () => getCodeList(),
   })
@@ -177,29 +183,42 @@ export default function CodeManager() {
           </IconButton>
         </Box>
         <Divider className="dark:border-gray-400" sx={{ mt: 1, mb: 1 }} />
-        <ul>
-          {categories
-            .filter(
-              (item) => !searchQuery || item.toLowerCase().includes(searchQuery.toLowerCase()),
-            )
-            .map((category) => (
-              <li className="mt-2" key={category}>
-                <Button
-                  fullWidth
-                  variant={selectedCategory === category ? "contained" : "outlined"}
-                  color="primary"
-                  className={`${
-                    selectedCategory === category
-                      ? "bg-primary text-white"
-                      : "border-primary bg-white text-primary dark:border-white dark:bg-black dark:text-white"
-                  }`}
-                  onClick={() => setSelectedCategory(category)}
-                >
-                  {category}
-                </Button>
-              </li>
-            ))}
-        </ul>
+        {isLoading || isFetching ? (
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              height: "10rem",
+            }}
+          >
+            <CircularProgress />
+          </Box>
+        ) : (
+          <ul>
+            {categories
+              .filter(
+                (item) => !searchQuery || item.toLowerCase().includes(searchQuery.toLowerCase()),
+              )
+              .map((category) => (
+                <li className="mt-2" key={category}>
+                  <Button
+                    fullWidth
+                    variant={selectedCategory === category ? "contained" : "outlined"}
+                    color="primary"
+                    className={`${
+                      selectedCategory === category
+                        ? "bg-primary text-white"
+                        : "border-primary bg-white text-primary dark:border-white dark:bg-black dark:text-white"
+                    }`}
+                    onClick={() => setSelectedCategory(category)}
+                  >
+                    {category}
+                  </Button>
+                </li>
+              ))}
+          </ul>
+        )}
       </Box>
 
       {/* 우측: 코드 목록 및 검색 */}

--- a/src/app/manage/code/page.tsx
+++ b/src/app/manage/code/page.tsx
@@ -156,8 +156,8 @@ export default function CodeManager() {
   return (
     <Box display="flex" gap={4}>
       {/* 좌측: 카테고리 목록 */}
-      <Box width="30%">
-        <Box mt={2} display="flex" alignItems="center" gap={1} className="dark:bg-black">
+      <Box width="20%">
+        <Box display="flex" alignItems="center" gap={1} className="dark:bg-black">
           <TextField
             variant="outlined"
             placeholder="검색어 입력"
@@ -203,20 +203,25 @@ export default function CodeManager() {
       </Box>
 
       {/* 우측: 코드 목록 및 검색 */}
-      <Box width="70%">
-        <Box display="flex" alignItems="center" gap={2} mb={2}>
+      <Box width="80%" className="border-l-2 pl-6">
+        <Box display="flex" alignItems="center" gap={1} mb={2}>
           <TextField
             variant="outlined"
             size="small"
             placeholder="새 카테고리"
             value={newCategory}
             onChange={(e) => setNewCategory(e.target.value)}
+            className="mt0"
           />
-          <Button variant="contained" color="primary" onClick={handleAddCategory}>
+          <Button
+            variant="contained"
+            onClick={handleAddCategory}
+            className="bg-primary text-xl shadow-none"
+          >
             +
           </Button>
 
-          <Box display="flex" gap={2} ml="auto">
+          <Box display="flex" gap={1} ml="auto">
             <Button
               variant="contained"
               color="primary"
@@ -231,10 +236,15 @@ export default function CodeManager() {
                   key: v4(),
                 })
               }
+              className="bg-primary shadow-none"
             >
               추가
             </Button>
-            <Button variant="contained" color="secondary" onClick={() => handleSave()}>
+            <Button
+              variant="contained"
+              className="bg-secondary shadow-none"
+              onClick={() => handleSave()}
+            >
               저장
             </Button>
           </Box>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,56 +1,54 @@
-import { shimmer } from "@/components/animations"
-import SNMSLogo from "@/components/logo"
-import { ArrowRightIcon, UserPlusIcon } from "@heroicons/react/24/outline"
-import Image from "next/image"
-import Link from "next/link"
+import { redirect } from "next/navigation"
 
 export default function Page() {
-  return (
-    <main className="flex min-h-screen flex-col p-4">
-      <div className={`${shimmer} relative overflow-hidden`}>
-        {/* <div className="relative overflow-hidden before:absolute before:inset-0 before:-translate-x-full before:animate-shimmer before:bg-gradient-shimmer before:from-transparent before:via-white/60 before:to-transparent"> */}
-        <div className="flex h-20 items-center rounded-lg bg-blue-500 p-2">
-          <SNMSLogo />
-        </div>
-      </div>
-      <div className="mt-4 flex grow flex-col gap-4 md:flex-row">
-        <div className="flex flex-col justify-center gap-6 rounded-lg bg-gray-50 px-6 py-10 md:w-3/5 md:px-20">
-          <p className="text-xl text-gray-800 md:text-3xl md:leading-normal">
-            <strong>Smart NMS에 오신걸 환영합니다.</strong> <br />
-            스마트한 네트워크 관리 시스템입니다.
-          </p>
-          <div className="flex gap-2">
-            <Link
-              href="/login"
-              className="flex items-center gap-2 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
-            >
-              로그인 <ArrowRightIcon className="w-5 md:w-2 lg:w-6" />
-            </Link>
-            <Link
-              href="/signup"
-              className="flex items-center gap-2 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
-            >
-              회원가입 <UserPlusIcon className="w-5 md:w-2 lg:w-6" />
-            </Link>
-          </div>
-        </div>
-        <div className="md:px-70 flex items-center justify-center p-6 md:w-4/5 md:py-12">
-          <Image
-            src="/main-desktop.png"
-            width={1000}
-            height={760}
-            className="hidden md:block"
-            alt="Screenshots of the dashboard project showing desktop version"
-          />
-          <Image
-            src="/main-desktop.png"
-            width={560}
-            height={620}
-            className="block md:hidden"
-            alt="Screenshot of the dashboard project showing mobile version"
-          />
-        </div>
-      </div>
-    </main>
-  )
+  redirect("/login")
+
+  // return (
+  //   <main className="flex min-h-screen flex-col p-4">
+  //     <div className={`${shimmer} relative overflow-hidden`}>
+  //       {/* <div className="relative overflow-hidden before:absolute before:inset-0 before:-translate-x-full before:animate-shimmer before:bg-gradient-shimmer before:from-transparent before:via-white/60 before:to-transparent"> */}
+  //       <div className="flex h-20 items-center rounded-lg bg-blue-500 p-2">
+  //         <SNMSLogo />
+  //       </div>
+  //     </div>
+  //     <div className="mt-4 flex grow flex-col gap-4 md:flex-row">
+  //       <div className="flex flex-col justify-center gap-6 rounded-lg bg-gray-50 px-6 py-10 md:w-3/5 md:px-20">
+  //         <p className="text-xl text-gray-800 md:text-3xl md:leading-normal">
+  //           <strong>Smart NMS에 오신걸 환영합니다.</strong> <br />
+  //           스마트한 네트워크 관리 시스템입니다.
+  //         </p>
+  //         <div className="flex gap-2">
+  //           <Link
+  //             href="/login"
+  //             className="flex items-center gap-2 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
+  //           >
+  //             로그인 <ArrowRightIcon className="w-5 md:w-2 lg:w-6" />
+  //           </Link>
+  //           <Link
+  //             href="/signup"
+  //             className="flex items-center gap-2 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
+  //           >
+  //             회원가입 <UserPlusIcon className="w-5 md:w-2 lg:w-6" />
+  //           </Link>
+  //         </div>
+  //       </div>
+  //       <div className="md:px-70 flex items-center justify-center p-6 md:w-4/5 md:py-12">
+  //         <Image
+  //           src="/main-desktop.png"
+  //           width={1000}
+  //           height={760}
+  //           className="hidden md:block"
+  //           alt="Screenshots of the dashboard project showing desktop version"
+  //         />
+  //         <Image
+  //           src="/main-desktop.png"
+  //           width={560}
+  //           height={620}
+  //           className="block md:hidden"
+  //           alt="Screenshot of the dashboard project showing mobile version"
+  //         />
+  //       </div>
+  //     </div>
+  //   </main>
+  // )
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,7 +6,7 @@ export default function LoginPage() {
   return (
     <Box className="h-screen bg-cover bg-center" sx={{ backgroundImage: "url('/login_bg.png')" }}>
       <Box className="flex h-full w-full items-center justify-center p-8">
-        <Box className="w-full max-w-md rounded-lg bg-white bg-opacity-90 px-10 py-12 shadow-lg">
+        <Box className="login_box_wrap w-full max-w-md rounded-lg bg-white bg-opacity-90 px-10 py-12 shadow-lg">
           <Box className="mb-2 flex justify-center">
             <Image src="/logo.png" width="130" height="40" alt="로고" className="h-10" />
           </Box>

--- a/src/components/account/login-form.tsx
+++ b/src/components/account/login-form.tsx
@@ -27,9 +27,24 @@ function LoginButton() {
 function JoinButton() {
   return (
     <Button
+      href="/signup"
       variant="contained"
       fullWidth
-      className="btn btn_join mt-4 h-12 !rounded-lg bg-white !text-base !font-normal text-primary !shadow-none hover:text-primary-dark"
+      // className="btn btn_join mt-4 h-12 !rounded-lg bg-white !text-base !font-normal text-primary !shadow-none hover:text-primary-dark"
+      sx={{
+        mt: "1rem",
+        height: "3rem",
+        borderRadius: "0.5rem",
+        backgroundColor: "white",
+        fontSize: "1rem",
+        fontWeight: "normal",
+        color: "rgb(20, 56, 150)",
+        boxShadow: "none",
+        "&:hover": {
+          color: "rgb(15, 43, 109)",
+          boxShadow: "none",
+        },
+      }}
     >
       회원가입
     </Button>
@@ -115,8 +130,22 @@ export default function LoginForm() {
           indicatorColor="primary"
           textColor="primary"
         >
-          <Tab className="flex-1 text-base" label="이메일 로그인" />
-          <Tab className="flex-1 text-base" label="QR 로그인" />
+          {/* <Tab className="flex-1 text-base" label="이메일 로그인" /> */}
+          <Tab
+            label="이메일 로그인"
+            sx={{
+              flex: 1, // TailwindCSS의 flex-1
+              fontSize: "1rem", // TailwindCSS의 text-base (16px)
+            }}
+          />
+          {/* <Tab className="flex-1 text-base" label="QR 로그인" /> */}
+          <Tab
+            label="QR 로그인"
+            sx={{
+              flex: 1, // TailwindCSS의 flex-1
+              fontSize: "1rem", // TailwindCSS의 text-base (16px)
+            }}
+          />
         </Tabs>
       </Box>
 

--- a/src/components/account/login-form.tsx
+++ b/src/components/account/login-form.tsx
@@ -17,9 +17,21 @@ function LoginButton() {
       type="submit"
       variant="contained"
       fullWidth
-      className="mt-6 h-12 rounded-lg bg-primary text-base font-normal shadow-none hover:bg-primary-dark"
+      className="btn btn_login !mt-6 !h-12 !rounded-lg !bg-primary !text-base !font-normal !shadow-none hover:!bg-primary-dark"
     >
       로그인
+    </Button>
+  )
+}
+
+function JoinButton() {
+  return (
+    <Button
+      variant="contained"
+      fullWidth
+      className="btn btn_join mt-4 h-12 !rounded-lg bg-white !text-base !font-normal text-primary !shadow-none hover:text-primary-dark"
+    >
+      회원가입
     </Button>
   )
 }
@@ -72,6 +84,7 @@ function FormLogin() {
         />
       </div>
       <LoginButton />
+      <JoinButton />
       <div className="flex h-8 items-end space-x-1" aria-live="polite" aria-atomic="true">
         {errorMessage && (
           <>

--- a/src/components/account/login-form.tsx
+++ b/src/components/account/login-form.tsx
@@ -2,7 +2,7 @@
 
 import { authenticate } from "@/actions/account-actions"
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline"
-import { Button } from "@mui/material"
+import { Box, Button, Tab, Tabs } from "@mui/material"
 import { useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { useFormState, useFormStatus } from "react-dom"
@@ -12,22 +12,19 @@ function LoginButton() {
   const { pending } = useFormStatus()
 
   return (
-    // <Button className="mt-4 w-full" aria-disabled={pending}>
-    //   로그인 <ArrowRightIcon className="ml-auto h-5 w-5 text-gray-50" />
-    // </Button>
     <Button
       aria-disabled={pending}
       type="submit"
       variant="contained"
       fullWidth
-      className="mt-6·h-12·rounded-lg·bg-primary·text-base·font-normal·shadow-none·hover:bg-primary-dark"
+      className="mt-6 h-12 rounded-lg bg-primary text-base font-normal shadow-none hover:bg-primary-dark"
     >
       로그인
     </Button>
   )
 }
 
-export default function LoginForm() {
+function FormLogin() {
   const [email, setEmail] = useState("")
   const [errorMessage, dispatch] = useFormState(authenticate, undefined)
 
@@ -83,8 +80,46 @@ export default function LoginForm() {
           </>
         )}
       </div>
-
-      <QRLogin />
     </form>
+  )
+}
+
+export default function LoginForm() {
+  const [activeTab, setActiveTab] = useState(0)
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue)
+  }
+
+  return (
+    <Box className="mx-auto w-full max-w-md">
+      {/* Tabs */}
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }} className="mb-6">
+        <Tabs
+          value={activeTab}
+          onChange={handleTabChange}
+          aria-label="login tabs"
+          indicatorColor="primary"
+          textColor="primary"
+        >
+          <Tab className="flex-1 text-base" label="이메일 로그인" />
+          <Tab className="flex-1 text-base" label="QR 로그인" />
+        </Tabs>
+      </Box>
+
+      {/* Tab Panels */}
+      <Box>
+        {activeTab === 0 && (
+          <Box>
+            <FormLogin />
+          </Box>
+        )}
+        {activeTab === 1 && (
+          <Box>
+            <QRLogin />
+          </Box>
+        )}
+      </Box>
+    </Box>
   )
 }

--- a/src/components/account/qrLogin.tsx
+++ b/src/components/account/qrLogin.tsx
@@ -59,7 +59,19 @@ export default function QRLogin() {
   return (
     <Box className="mt-4 flex flex-col items-center">
       {/* 로딩 중일 때 */}
-      {loading && <CircularProgress />}
+      {loading && (
+        <Box
+          sx={{
+            width: "200px",
+            height: "200px",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      )}
 
       {/* 에러 발생 시 */}
       {error && <p className="text-red-500">{error}</p>}

--- a/src/components/account/qrLogin.tsx
+++ b/src/components/account/qrLogin.tsx
@@ -68,7 +68,7 @@ export default function QRLogin() {
       {qrUrl && !loading && <Image src={qrUrl} alt="QR 코드" width={200} height={200} />}
 
       {/* QR 코드 갱신 버튼 (선택 사항) */}
-      <Button variant="outlined" onClick={fetchQrCode} className="mt-4">
+      <Button variant="outlined" onClick={fetchQrCode} className="mt-6">
         새로고침
       </Button>
     </Box>

--- a/src/components/account/qrLogin.tsx
+++ b/src/components/account/qrLogin.tsx
@@ -68,7 +68,11 @@ export default function QRLogin() {
       {qrUrl && !loading && <Image src={qrUrl} alt="QR 코드" width={200} height={200} />}
 
       {/* QR 코드 갱신 버튼 (선택 사항) */}
-      <Button variant="outlined" onClick={fetchQrCode} className="mt-6">
+      <Button
+        variant="outlined"
+        onClick={fetchQrCode}
+        className="mt-6 h-12 w-full rounded-lg text-base !font-normal"
+      >
         새로고침
       </Button>
     </Box>

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -153,15 +153,15 @@ export default function Menu({
 
     // 순서대로 2,3,4뎁스 용 스타일
     const depthDivStyle = [
-      "absolute left-1/2 top-full z-50 w-48 -translate-x-1/2 transform bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
-      "absolute left-full top-0 z-50 w-48 bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
-      "absolute left-full top-0 z-50 w-48 bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
+      "depth2 absolute left-1/2 top-full z-50 w-48 -translate-x-1/2 transform bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
+      "depth3 absolute left-full top-0 z-50 w-48 bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
+      "depth4 absolute left-full top-0 z-50 w-48 bg-white text-gray-800 shadow-lg dark:bg-gray-900 dark:text-white",
     ]
 
     const depthLiStyle = [
-      "hover:text-primary relative cursor-pointer px-4 py-2 dark:hover:text-point",
-      "px-4 py-2 relative hover:bg-gray-100 dark:hover:text-point dark:bg-gray-900 dark:hover:bg-gray-800",
-      "px-4 py-2 relative hover:bg-gray-100 dark:hover:text-point dark:bg-gray-900 dark:hover:bg-gray-800",
+      "hover:text-primary relative cursor-pointer dark:hover:text-point",
+      "relative hover:bg-gray-100 hover:text-primary dark:hover:text-point dark:bg-gray-900 dark:hover:bg-gray-800",
+      "relative hover:bg-gray-100 dark:hover:text-point dark:bg-gray-900 dark:hover:bg-gray-800",
     ]
 
     return (
@@ -215,7 +215,7 @@ export default function Menu({
               key={menu.menu_id}
               onMouseEnter={() => handleMouseEnter(menu.menu_id, 0)}
               onMouseLeave={handleMouseLeave}
-              className="relative"
+              className="gnb_menu relative"
             >
               <button
                 type="button"

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -117,7 +117,9 @@ export default function Menu({
     const url = menu.url ?? ""
     const width = menu.screen_width ?? 800
     const height = menu.screen_width ?? 600
-    window.open(url, "_blank", `noopener,noreferrer,width=${width},height=${height},top=50,left=50`)
+
+    // 아이디로 추적할거면 noopener,noreferrer 못씀
+    window.open(url, url, `width=${width},height=${height},top=50,left=50`)
   }
 
   function renderMenuLink(menu: MenuType) {
@@ -134,8 +136,9 @@ export default function Menu({
       }
       // 새탭
       if (menu.pop_up_yn_code === "T") {
+        // 아이디로 추적할거면 rel="noopener noreferrer" 못씀
         return (
-          <Link href={menu.url ?? ""} target="_blank" rel="noopener noreferrer">
+          <Link href={menu.url ?? ""} target={menu.url ?? ""}>
             {menu.menu_name}
           </Link>
         )
@@ -186,9 +189,9 @@ export default function Menu({
   const toggleTheme = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newTheme = event.target.checked ? "dark" : "light"
     setTheme(newTheme)
-    setGrafanaTheme(newTheme as "dark" | "light")
+    // setGrafanaTheme(newTheme as "dark" | "light")
 
-    document.documentElement.className = newTheme
+    // document.documentElement.className = newTheme
 
     setCookie("theme", newTheme, 30)
 

--- a/src/components/common/Top.tsx
+++ b/src/components/common/Top.tsx
@@ -15,7 +15,26 @@ export default function Top({ breadcrumbs }: { breadcrumbs: BreadcrumbType[] }) 
   return (
     <Box display="flex" alignItems="center" justifyContent="space-between" className="mb-3">
       {/* 페이지 제목 */}
-      <Typography variant="h5" className="font-semibold text-gray-800 dark:text-white">
+      <Typography
+        variant="h5"
+        // className="font-semibold text-gray-800 dark:text-white"
+        // sx={{
+        //   fontWeight: 600,
+        //   color: "rgb(31, 41, 55)",
+        //   "&.Mui-dark": {
+        //     color: "rgb(255, 255, 255)",
+        //   },
+        // }}
+        sx={[
+          (theme) => ({
+            fontWeight: 600,
+            color: "rgb(31, 41, 55)",
+            ...theme.applyStyles("dark", {
+              color: "rgb(255, 255, 255)",
+            }),
+          }),
+        ]}
+      >
         {currentBreadcrumb?.path_names?.[currentBreadcrumb.path_names.length - 1] ||
           "메뉴 미등록 화면"}
       </Typography>

--- a/src/components/dashboard/GrafanaIframe.tsx
+++ b/src/components/dashboard/GrafanaIframe.tsx
@@ -1,7 +1,8 @@
 import { grafanaThemeAtom } from "@/atom/dashboardAtom"
 import { useContextPath } from "@/config/Providers"
+import { Box } from "@mui/material"
 import { useAtom } from "jotai"
-import { useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 interface GrafanaIframeProps {
   src: string
@@ -13,6 +14,7 @@ export function GrafanaIframe({ src, selected, title }: GrafanaIframeProps) {
   const contextPath = useContextPath()
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const [theme] = useAtom(grafanaThemeAtom)
+  const [loaded, setLoaded] = useState(false)
 
   // height 자동조정 스크립트. 11버전으로 가면서(autofitheight) 필요없어짐.
 
@@ -55,6 +57,22 @@ export function GrafanaIframe({ src, selected, title }: GrafanaIframeProps) {
   //     if (intervalRef.current) clearInterval(intervalRef.current)
   //   }
   // }, [adjustHeight, selected])
+
+  useEffect(() => {
+    setLoaded(true)
+  }, [])
+
+  if (!loaded) {
+    return (
+      <Box
+        sx={{
+          width: "100%",
+          height: "750px", // iframe과 동일한 높이
+          backgroundColor: "transparent", // 배경 투명
+        }}
+      />
+    )
+  }
 
   return (
     <iframe

--- a/src/components/equip/EquipTable.tsx
+++ b/src/components/equip/EquipTable.tsx
@@ -76,14 +76,14 @@ export function EquipTable({ selectedEquipTypeCode }: EquipTableProps) {
   }
 
   return (
-    <TableContainer component={Paper} className="p-4">
+    <TableContainer component={Paper}>
       <Table aria-label="simple table">
-        <TableHead>
+        <TableHead className="bg-gray-200 dark:bg-gray-800">
           <TableRow>
             {columns.map((column) => (
               <TableCell
                 key={column.name}
-                className="whitespace-nowrap font-semibold text-gray-600"
+                className="whitespace-nowrap font-semibold text-gray-600 dark:text-white"
               >
                 {column.comment}
               </TableCell>
@@ -96,7 +96,11 @@ export function EquipTable({ selectedEquipTypeCode }: EquipTableProps) {
         <TableBody>
           {equips.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={columns.length} align="center">
+              <TableCell
+                className="dark:bg-black dark:text-white"
+                colSpan={columns.length}
+                align="center"
+              >
                 <Typography variant="body1">좌측 분류에서 선택해주세요</Typography>
               </TableCell>
             </TableRow>
@@ -109,7 +113,10 @@ export function EquipTable({ selectedEquipTypeCode }: EquipTableProps) {
                   // 날짜 컬럼 처리
                   if (column.name.toLowerCase().includes("date")) {
                     return (
-                      <TableCell key={column.name} className="whitespace-nowrap">
+                      <TableCell
+                        key={column.name}
+                        className="whitespace-nowrap dark:bg-black dark:text-white"
+                      >
                         {formatDate(String(value))}
                       </TableCell>
                     )
@@ -117,11 +124,19 @@ export function EquipTable({ selectedEquipTypeCode }: EquipTableProps) {
 
                   // 일반 값 처리
                   if (value !== null && value !== undefined) {
-                    return <TableCell key={column.name}>{String(value)}</TableCell>
+                    return (
+                      <TableCell className="dark:bg-black dark:text-white" key={column.name}>
+                        {String(value)}
+                      </TableCell>
+                    )
                   }
 
                   // 값이 null 또는 undefined인 경우
-                  return <TableCell key={column.name}>N/A</TableCell>
+                  return (
+                    <TableCell className="dark:bg-black dark:text-white" key={column.name}>
+                      N/A
+                    </TableCell>
+                  )
                 })}
               </TableRow>
             ))

--- a/src/components/equip/EquipTree.tsx
+++ b/src/components/equip/EquipTree.tsx
@@ -51,6 +51,7 @@ export function EquipTree({ onSelectEquipTypeCode }: EquipTreeProps) {
         {groupBy(netTypeGroups[netType], "equip_type_code") &&
           Object.keys(groupBy(netTypeGroups[netType], "equip_type_code")).map((equipType) => (
             <TreeItem
+              className="py-2"
               key={equipType}
               itemId={equipType + index}
               label={equipType}

--- a/src/components/equip/EquipTree.tsx
+++ b/src/components/equip/EquipTree.tsx
@@ -2,28 +2,20 @@ import { getEquipList } from "@/actions/equip-actions"
 import { EquipType } from "@/types/equip"
 import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
+import { Box, CircularProgress } from "@mui/material"
 import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView"
 import { TreeItem } from "@mui/x-tree-view/TreeItem"
-import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 
 type EquipTreeProps = {
   onSelectEquipTypeCode: (equipId: string) => void
 }
 
 export function EquipTree({ onSelectEquipTypeCode }: EquipTreeProps) {
-  const [equips, setEquips] = useState<Partial<EquipType>[]>([])
-
-  useEffect(() => {
-    getEquipList()
-      .then((data) => {
-        // console.table(data)
-        // console.log(JSON.stringify(data))
-        setEquips(data)
-      })
-      .catch((error) => {
-        console.error("데이터를 불러오는 데 실패했습니다:", error)
-      })
-  }, [])
+  const { data: equipList = [], isLoading } = useQuery({
+    queryKey: ["equipList"],
+    queryFn: () => getEquipList(),
+  })
 
   const groupBy = (array: Partial<EquipType>[], key: "net_type_code" | "equip_type_code") => {
     return array.reduce(
@@ -43,7 +35,7 @@ export function EquipTree({ onSelectEquipTypeCode }: EquipTreeProps) {
   // 트리 항목을 렌더링하는 함수
   const renderTreeItems = () => {
     // 먼저 NET_TYPE_CODE로 그룹화
-    const netTypeGroups = groupBy(equips, "net_type_code")
+    const netTypeGroups = groupBy(equipList, "net_type_code")
 
     return Object.keys(netTypeGroups).map((netType, index) => (
       <TreeItem key={netType} itemId={netType} label={netType}>
@@ -72,6 +64,21 @@ export function EquipTree({ onSelectEquipTypeCode }: EquipTreeProps) {
           ))}
       </TreeItem>
     ))
+  }
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "10rem",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    )
   }
 
   return (

--- a/src/components/main/BoardDialog.tsx
+++ b/src/components/main/BoardDialog.tsx
@@ -145,7 +145,7 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
     >
       {articleId === null && (
         <>
-          <DialogTitle>{label}</DialogTitle>
+          <DialogTitle className="dark:text-white">{label}</DialogTitle>
           <DialogContent
             sx={{
               display: "flex",
@@ -159,18 +159,21 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
                 flexGrow: 1, // 테이블 컨텐츠가 가변적으로 크기를 차지하도록 설정
                 overflowY: "auto", // 테이블 내용이 많을 경우 스크롤 가능하게 설정
               }}
+              className="border dark:border-gray-700 dark:bg-black"
             >
               <Table size="small">
                 <TableHead>
                   <TableRow sx={{ height: "40px" }}>
-                    <TableCell sx={{ paddingY: "0px" }}>제목</TableCell>
-                    <TableCell align="right" sx={{ paddingY: "0px" }}>
+                    <TableCell sx={{ paddingY: "0px" }} className="dark:text-white">
+                      제목
+                    </TableCell>
+                    <TableCell align="right" sx={{ paddingY: "0px" }} className="dark:text-white">
                       날짜
                     </TableCell>
-                    {/* <TableCell align="right" sx={{ paddingY: "0px" }}>
+                    {/* <TableCell align="right" sx={{ paddingY: "0px" }} className="dark:text-white">
                       수정
                     </TableCell>
-                    <TableCell align="right" sx={{ paddingY: "0px" }}>
+                    <TableCell align="right" sx={{ paddingY: "0px" }} className="dark:text-white">
                       삭제
                     </TableCell> */}
                   </TableRow>
@@ -179,19 +182,15 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
                   {boards.map((board) => (
                     <TableRow
                       key={board.id}
-                      sx={{
-                        height: "40px",
-                        cursor: "pointer",
-                        "&:hover": {
-                          backgroundColor: "#F6FAFD", // hover 시 로우 색상 변경
-                        },
-                      }}
                       onClick={() => handleView(board.id ?? "")}
+                      className="h-10 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
                     >
                       <TableCell sx={{ paddingY: "0px" }}>
-                        <Typography className="w-128 truncate">{board.title}</Typography>
+                        <Typography className="w-128 truncate dark:text-white">
+                          {board.title}
+                        </Typography>
                       </TableCell>
-                      <TableCell align="right" sx={{ paddingY: "0px" }}>
+                      <TableCell align="right" sx={{ paddingY: "0px" }} className="dark:text-white">
                         {formatDate(board.create_date ?? "")}
                       </TableCell>
                       {/* <TableCell align="right" sx={{ paddingY: "0px" }}>
@@ -221,18 +220,19 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
                 page={page} // 현재 페이지
                 onChange={(_, value) => handlePageChange(value)} // 페이지 변경 시 호출되는 함수
                 color="primary"
+                className="dark:text-white"
                 shape="rounded"
               />
             </Box>
           </DialogContent>
 
           {/* Dialog Actions */}
-          <DialogActions>
+          <DialogActions className="p-4 pt-0 dark:bg-black">
             {/* 일단 readOnly 로 조회만 할 수 있게 */}
             {/* <Button onClick={handleAdd} startIcon={<Add />}>
               추가
             </Button> */}
-            <Button onClick={handleClose} color="primary">
+            <Button onClick={handleClose} color="primary" className="dark:text-white">
               닫기
             </Button>
           </DialogActions>
@@ -240,7 +240,7 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
       )}
       {articleId !== null && (
         <>
-          <DialogTitle>{label}</DialogTitle>
+          <DialogTitle className="dark:bg-black dark:text-white">{label}</DialogTitle>
           <DialogContent
             sx={{
               display: "flex",
@@ -248,6 +248,7 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
               gap: 2, // 요소 간 간격 추가
               padding: "36px", // 내부 패딩 추가
             }}
+            className="dark:bg-black dark:text-white"
           >
             {/* 제목 */}
             {articleId === "" ? (
@@ -318,11 +319,11 @@ export function BoardDialog({ section, label, open, handleClose, miniId }: Board
           </DialogContent>
 
           {/* Dialog Actions */}
-          <DialogActions sx={{ padding: "16px" }}>
+          <DialogActions className="p-4 pt-0 dark:bg-black">
             {/* <Button onClick={handleAdd} startIcon={<Add />}>
               저장
             </Button> */}
-            <Button onClick={handleArticleBack} color="primary">
+            <Button onClick={handleArticleBack} color="primary" className="dark:text-white">
               뒤로
             </Button>
           </DialogActions>

--- a/src/components/main/MiniBoard.tsx
+++ b/src/components/main/MiniBoard.tsx
@@ -89,7 +89,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         <Typography variant="h6" className="font-bold">
           {label}
         </Typography>
-        <Button size="small" variant="text" className="dark:text-primary-light text-primary">
+        <Button size="small" variant="text" className="text-primary dark:text-primary-light">
           <Box className="flex items-center" onClick={handleOpenDialog}>
             <AddIcon fontSize="small" />
             <span className="text-base">More</span>
@@ -100,7 +100,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         {boards.map((notice) => (
           <li key={notice.id}>
             <Box
-              className="dark:hover:text-primary-light flex cursor-pointer justify-between hover:text-primary"
+              className="flex cursor-pointer justify-between hover:text-primary dark:hover:text-primary-light"
               onClick={() => handleClick(notice.id ?? "")}
             >
               <span className="w-9/12 truncate">{notice.title}</span>

--- a/src/components/main/MiniBoard.tsx
+++ b/src/components/main/MiniBoard.tsx
@@ -1,7 +1,7 @@
 import { getBoardList } from "@/actions/board-action"
 import { BoardType } from "@/types/board"
 import AddIcon from "@mui/icons-material/Add"
-import { Box, Button, Typography } from "@mui/material"
+import { Box, Button, CircularProgress, Typography } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { BoardDialog } from "./BoardDialog"
@@ -37,7 +37,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
   //       }),
   // })
 
-  const { data: boardsResult } = useQuery({
+  const { data: boardsResult, isLoading } = useQuery({
     queryKey: ["board", section, "MiniBoard"], // 캐시 키
     queryFn: () => getBoardList({ section, page: 1, rowsPerPage: 10, count: 3 }),
   })
@@ -86,10 +86,26 @@ export function MiniBoard({ section, label }: { section: string; label: string }
   return (
     <>
       <Box className="mb-3 flex items-center justify-between">
-        <Typography variant="h6" className="font-bold">
+        <Typography
+          variant="h6"
+          // className="font-bold"
+          sx={{ fontWeight: 700 }}
+        >
           {label}
         </Typography>
-        <Button size="small" variant="text" className="text-primary dark:text-primary-light">
+        <Button
+          size="small"
+          variant="text"
+          // className="text-primary dark:text-primary-light"
+          sx={[
+            (theme) => ({
+              color: "rgb(20, 56, 150)",
+              ...theme.applyStyles("dark", {
+                color: "rgb(125, 160, 255)",
+              }),
+            }),
+          ]}
+        >
           <Box className="flex items-center" onClick={handleOpenDialog}>
             <AddIcon fontSize="small" />
             <span className="text-base">More</span>
@@ -97,19 +113,32 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         </Button>
       </Box>
       <ul className="space-y-2">
-        {boards.map((notice) => (
-          <li key={notice.id}>
-            <Box
-              className="flex cursor-pointer justify-between hover:text-primary dark:hover:text-primary-light"
-              onClick={() => handleClick(notice.id ?? "")}
-            >
-              <span className="w-9/12 truncate">{notice.title}</span>
-              <span className="min-w-min whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
-                {formatDate(notice.create_date ?? "")}
-              </span>
-            </Box>
-          </li>
-        ))}
+        {isLoading ? (
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              height: "88px",
+            }}
+          >
+            <CircularProgress />
+          </Box>
+        ) : (
+          boards.map((notice) => (
+            <li key={notice.id}>
+              <Box
+                className="flex cursor-pointer justify-between hover:text-primary dark:hover:text-primary-light"
+                onClick={() => handleClick(notice.id ?? "")}
+              >
+                <span className="w-9/12 truncate">{notice.title}</span>
+                <span className="min-w-min whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                  {formatDate(notice.create_date ?? "")}
+                </span>
+              </Box>
+            </li>
+          ))
+        )}
       </ul>
       <BoardDialog
         open={openDialog}

--- a/src/components/main/MiniBoard.tsx
+++ b/src/components/main/MiniBoard.tsx
@@ -89,7 +89,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         <Typography variant="h6" className="font-bold">
           {label}
         </Typography>
-        <Button size="small" variant="text" className="text-primary dark:text-primary-light">
+        <Button size="small" variant="text" className="dark:text-primary-light text-primary">
           <Box className="flex items-center" onClick={handleOpenDialog}>
             <AddIcon fontSize="small" />
             <span className="text-base">More</span>
@@ -100,7 +100,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         {boards.map((notice) => (
           <li key={notice.id}>
             <Box
-              className="flex cursor-pointer justify-between hover:text-primary dark:hover:text-primary-light"
+              className="dark:hover:text-primary-light flex cursor-pointer justify-between hover:text-primary"
               onClick={() => handleClick(notice.id ?? "")}
             >
               <span className="w-9/12 truncate">{notice.title}</span>

--- a/src/components/main/MiniBoard.tsx
+++ b/src/components/main/MiniBoard.tsx
@@ -89,7 +89,7 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         <Typography variant="h6" className="font-bold">
           {label}
         </Typography>
-        <Button size="small" variant="text" className="text-primary">
+        <Button size="small" variant="text" className="text-primary dark:text-primary-light">
           <Box className="flex items-center" onClick={handleOpenDialog}>
             <AddIcon fontSize="small" />
             <span className="text-base">More</span>
@@ -100,11 +100,11 @@ export function MiniBoard({ section, label }: { section: string; label: string }
         {boards.map((notice) => (
           <li key={notice.id}>
             <Box
-              className="flex cursor-pointer justify-between hover:text-primary"
+              className="flex cursor-pointer justify-between hover:text-primary dark:hover:text-primary-light"
               onClick={() => handleClick(notice.id ?? "")}
             >
               <span className="w-9/12 truncate">{notice.title}</span>
-              <span className="min-w-min whitespace-nowrap text-sm text-gray-500">
+              <span className="min-w-min whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
                 {formatDate(notice.create_date ?? "")}
               </span>
             </Box>

--- a/src/config/Providers.tsx
+++ b/src/config/Providers.tsx
@@ -22,7 +22,13 @@ export function ToastProvider() {
 }
 //
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  darkLightTheme,
+}: {
+  children: React.ReactNode
+  darkLightTheme: "light" | "dark"
+}) {
   // react query 설정
   const [queryClient] = useState(
     () =>
@@ -43,6 +49,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   // MUI
   const theme = createTheme({
+    palette: { mode: darkLightTheme },
     components: {
       // 버튼 자동대문자 변환 방지
       MuiButton: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,3 +14,9 @@
 .css-1qltlow-MuiTabs-indicator {
   background-color: #143896 !important;
 }
+
+*,
+.MuiButtonBase-root,
+.btn {
+  font-family: "__Noto_Sans_KR_23d4f0", "__Noto_Sans_KR_Fallback_23d4f0";
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,4 +19,8 @@
 .MuiButtonBase-root,
 .btn {
   font-family: "__Noto_Sans_KR_23d4f0", "__Noto_Sans_KR_Fallback_23d4f0";
+.login_box_wrap {
+  max-height: 84vh;
+  overflow-y: auto;
+}
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,3 +7,10 @@
   color: #fff;
   border-radius: 4px;
 }
+
+.css-1usuzwp-MuiButtonBase-root-MuiTab-root.Mui-selected {
+  color: #143896 !important;
+}
+.css-1qltlow-MuiTabs-indicator {
+  background-color: #143896 !important;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -27,4 +27,19 @@
   max-height: 84vh;
   overflow-y: auto;
 }
+
+.gnb_menu .depth2 > ul > li:not(:has(> a)) {
+  padding: 0.5rem 1rem;
+}
+.gnb_menu .depth2 > ul > li:has(> a) {
+  padding: 0;
+}
+.gnb_menu .depth2 > ul > li > a {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+}
+.gnb_menu .depth3 a {
+  display: block;
+  padding: 0.5rem 1rem;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -66,3 +66,12 @@
 .css-5hf2k4-MuiFormControl-root-MuiTextField-root {
   margin-top: 0;
 }
+
+.MuiSimpleTreeView-root {
+  box-shadow: none;
+  padding: 10px;
+}
+.dark .css-1it4x0c-MuiSimpleTreeView-root {
+  background: #1f2937;
+  color: #fff;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -43,3 +43,19 @@
   display: block;
   padding: 0.5rem 1rem;
 }
+
+.dark .css-183dk5e-MuiFormLabel-root-MuiInputLabel-root.MuiInputLabel-shrink {
+  color: #fff !important;
+}
+.dark .MuiDialog-paper {
+  background: #000;
+}
+.dark .MuiOutlinedInput-root {
+  background: #2c2c2c;
+}
+.dark .MuiTableCell-root {
+  border-bottom-color: #374151;
+}
+.dark .MuiPaginationItem-root {
+  color: white;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -18,7 +20,9 @@
 *,
 .MuiButtonBase-root,
 .btn {
-  font-family: "__Noto_Sans_KR_23d4f0", "__Noto_Sans_KR_Fallback_23d4f0";
+  font-family: "NotoSans" !important;
+}
+
 .login_box_wrap {
   max-height: 84vh;
   overflow-y: auto;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,3 +59,10 @@
 .dark .MuiPaginationItem-root {
   color: white;
 }
+
+.MuiPaper-root {
+  box-shadow: none;
+}
+.css-5hf2k4-MuiFormControl-root-MuiTextField-root {
+  margin-top: 0;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
         primary: "#143896",
         "primary-light": "#7da0ff",
         "primary-dark": "#0f2b6d",
+        secondary: "#4496e5",
         point: "#49CBFF",
         blue: { 400: "#2589FE", 500: "#0070F3", 600: "#2F6FEB" },
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,9 @@ const config: Config = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['"Noto Sans"', "Apple SD Gothic Neo", "Roboto", "sans-serif"],
+      },
       colors: {
         primary: "#143896",
         "primary-dark": "#0f2b6d",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
       },
       colors: {
         primary: "#143896",
+        "primary-light": "#7da0ff",
         "primary-dark": "#0f2b6d",
         point: "#49CBFF",
         blue: { 400: "#2589FE", 500: "#0070F3", 600: "#2F6FEB" },


### PR DESCRIPTION
[퍼블]
메인화면, 구성관리, 공통코드 - 다크모드 추가
로그인 화면 - QR 탭으로 구성, 회원가입 버튼 추가 완료
폰트 로딩, height 등 css 덮어씌어지는 이슈
GNB - 메뉴 선택 link 영역 hover 영역과 같아지도록 수정 완료

[개발]
Menu noreferrer 원복
GrafanaIframe loaded 원복
mui 다크모드 적용
루트 페이지는 login 으로
mui 컴포넌트에 tailwindcss 적용하지 않도록
로딩 UI