### PR TITLE
fix: 로그인/메인페이지 및 로그인이 필요없는 페이지를 상수로 등록해서 관리하도록 수정

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import LoginForm from "@/components/account/login-form"
+import { LOGIN_DEFAULT_PAGE } from "@/config/const"
 import { Box } from "@mui/material"
 import { auth } from "auth"
 import Image from "next/image"
@@ -12,7 +13,7 @@ export default async function Login({
 }) {
   const session = await auth()
   if (session) {
-    redirect(searchParams?.callbackUrl ?? "/main")
+    redirect(searchParams?.callbackUrl ?? LOGIN_DEFAULT_PAGE)
   }
 
   return (

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { grafanaThemeAtom } from "@/atom/dashboardAtom"
+import { LOGIN_DEFAULT_PAGE } from "@/config/const"
 import { MenuType } from "@/types/menu"
 import { Box, FormControlLabel } from "@mui/material"
 import { styled } from "@mui/material/styles"
@@ -207,7 +208,7 @@ export default function Menu({
 
   return (
     <div className="flex items-center">
-      <Link href="/main">
+      <Link href={LOGIN_DEFAULT_PAGE}>
         <Image src="/logo_w.svg" width={130} height={40} alt="Logo" className="mr-10 h-8" />
       </Link>
       <nav className="relative flex space-x-6">

--- a/src/components/common/Top.tsx
+++ b/src/components/common/Top.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { LOGIN_DEFAULT_PAGE } from "@/config/const"
 import { BreadcrumbType } from "@/types/menu"
 import { Box, Breadcrumbs, Link, Typography } from "@mui/material"
 import { usePathname } from "next/navigation"
@@ -48,7 +49,7 @@ export default function Top({ breadcrumbs }: { breadcrumbs: BreadcrumbType[] }) 
           fontSize: "0.875rem",
         }}
       >
-        <Link href="/main" underline="hover" color="inherit">
+        <Link href={LOGIN_DEFAULT_PAGE} underline="hover" color="inherit">
           Home
         </Link>
         {currentBreadcrumb?.path_names.map((name, index) => (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { auth } from "auth"
 import NextAuth from "next-auth"
 import { NextRequest, NextResponse } from "next/server"
 import { authConfig } from "../auth.config"
+import { NO_LOGIN_DEFAULT_PAGE, NO_LOGIN_PAGES } from "./config/const"
 
 export default NextAuth(authConfig).auth
 
@@ -13,11 +14,11 @@ export async function middleware(request: NextRequest) {
   // console.log(session)
   // console.log("session")
   const { pathname } = request.nextUrl
-  const noLoginPage =
-    pathname === "/" || pathname.startsWith("/login") || pathname.startsWith("/signup")
+  const noLoginPage = NO_LOGIN_PAGES.includes(pathname)
+  // pathname === "/" || pathname.startsWith("/login") || pathname.startsWith("/signup")
 
   if (!session && !noLoginPage) {
-    return NextResponse.redirect(new URL(`/login`, request.url))
+    return NextResponse.redirect(new URL(NO_LOGIN_DEFAULT_PAGE, request.url))
   }
 
   const headers = new Headers(request.headers)


### PR DESCRIPTION
export const NO_LOGIN_PAGES = ["/", "/login", "/signup"]
export const NO_LOGIN_DEFAULT_PAGE = "/login"
export const LOGIN_DEFAULT_PAGE = "/main"